### PR TITLE
Update module path for v3

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	ipfsethdb "github.com/vulcanize/ipfs-ethdb"
+	ipfsethdb "github.com/vulcanize/ipfs-ethdb/v3"
 )
 
 var (

--- a/database_test.go
+++ b/database_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	ipfsethdb "github.com/vulcanize/ipfs-ethdb"
+	ipfsethdb "github.com/vulcanize/ipfs-ethdb/v3"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vulcanize/ipfs-ethdb
+module github.com/vulcanize/ipfs-ethdb/v3
 
 go 1.15
 

--- a/postgres/batch_test.go
+++ b/postgres/batch_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	pgipfsethdb "github.com/vulcanize/ipfs-ethdb/postgres"
+	pgipfsethdb "github.com/vulcanize/ipfs-ethdb/v3/postgres"
 )
 
 var (

--- a/postgres/database_test.go
+++ b/postgres/database_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	pgipfsethdb "github.com/vulcanize/ipfs-ethdb/postgres"
+	pgipfsethdb "github.com/vulcanize/ipfs-ethdb/v3/postgres"
 )
 
 var (

--- a/postgres/doc.md
+++ b/postgres/doc.md
@@ -18,7 +18,7 @@ import (
     "github.com/ethereum/go-ethereum/core/state"
     "github.com/ethereum/go-ethereum/trie"
     "github.com/jmoiron/sqlx"
-    "github.com/vulcanize/ipfs-ethdb/postgres"
+    "github.com/vulcanize/ipfs-ethdb/v3/postgres"
 )
 
 func main() {


### PR DESCRIPTION
Part of https://github.com/vulcanize/go-ethereum/issues/127

- Change module path from `github.com/vulcanize/ipfs-ethdb` to `github.com/vulcanize/ipfs-ethdb/v3` for v3