### PR TITLE
Deregister groupcache on close

### DIFF
--- a/postgres/v0/database.go
+++ b/postgres/v0/database.go
@@ -278,9 +278,10 @@ func (d *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	return NewIterator(start, prefix, d.db)
 }
 
-// Close satisfies the io.Closer interface
-// Close closes the db connection
+// Close satisfies the io.Closer interface.
+// Close closes the db connection and deregisters from groupcache.
 func (d *Database) Close() error {
+	groupcache.DeregisterGroup(d.cache.Name())
 	return d.db.DB.Close()
 }
 


### PR DESCRIPTION
With this, we can close a Database instance and create one with the same name in the same process (useful in tests and https://github.com/cerc-io/ipld-eth-db-validator/pull/32 depends on it)